### PR TITLE
Add prerequisites

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -13,7 +13,9 @@ WriteMakefile(
     PL_FILES            => {},
     PREREQ_PM => {
         'Test::More' => 0,
-        'Config::General' => 0,
+	'Catalyst' => 0,
+	'DBIx::Class' => 0,
+	'DBD::SQLite' => 0,
     },
     dist                => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean               => { FILES => 'Quitanda-*' },


### PR DESCRIPTION
Add some basic prerequisites to the make file. Probably the version of ExtUtils::MakeMaker could be dumped so that we only needed DBD::Sqlite for testing. This PR is a result of the pullrequest club.